### PR TITLE
fix: requireValueOf が .strip() と .passthrough() を正しく扱えるように

### DIFF
--- a/layers/base/app/utils/zod.ts
+++ b/layers/base/app/utils/zod.ts
@@ -20,8 +20,7 @@ export function ensureValueOf<T>(
 }
 
 export function requireValueOf<T>(x: ZodType<T, ZodTypeDef>, y: unknown): T {
-  ensureValueOf(x, y)
-  return y
+  return x.parse(y)
 }
 
 // const language = { 0: 'ja', 1: 'en'} as const みたいなオブジェクトのValueのunion型をzodでつかえるようにするメソッド


### PR DESCRIPTION
### Ticket, Issues
- #9 

### Actions
- requireValueOf() を schema.parse(input) の戻り値をそのまま返すように変更

### Points and Notes
- 

### Evidences
- 
