### PR TITLE
mainレイヤーで自身のコンポーネントを参照できなかったのでtsconfigを調整

### DIFF
--- a/layers/base/app/composables/useToast.ts
+++ b/layers/base/app/composables/useToast.ts
@@ -1,8 +1,5 @@
 import { useNuxtApp } from 'nuxt/app'
 import { InjectionKey } from 'vue'
-import { ToastType } from 'vue3-toastify'
-import { z } from 'zod'
-import { ensureValueOf } from '#base/app/utils/zod'
 
 export const useToast = () => {
   const { $toast } = useNuxtApp()
@@ -12,16 +9,10 @@ export const useToast = () => {
    */
   const addToast = (
     text: string,
-    type?: ToastType,
+    type?: 'info' | 'success' | 'error' | 'warning',
     time?: number,
     isClosable = false,
   ) => {
-    ensureValueOf(z.function(), $toast)
-    ensureValueOf(z.function(), $toast.info)
-    ensureValueOf(z.function(), $toast.success)
-    ensureValueOf(z.function(), $toast.warning)
-    ensureValueOf(z.function(), $toast.error)
-
     $toast[type ?? 'info'](text, {
       delay: time,
       closeButton: isClosable,

--- a/layers/base/tsconfig.json
+++ b/layers/base/tsconfig.json
@@ -3,25 +3,6 @@
   "extends": [
     "./.nuxt/tsconfig.server.json",
     "./.nuxt/tsconfig.json",
-    "../../tsconfig.shared.json"
+    "./tsconfig.shared.json"
   ],
-  "compilerOptions": {
-    "lib": ["dom", "ES2023"],
-    "typeRoots": [
-      "../../node_modules",
-      "../../node_modules/@types",
-      "./@types"
-    ],
-    "types": [
-      "@types/uuid",
-      "vue3-toastify/global",
-      "unplugin-icons/types/vue",
-      "vite/client",
-      "vitest/globals"
-    ],
-    "paths": {
-      "#base/*": ["./*"]
-    }
-  },
-  "exclude": ["node_modules", ".output", "dist"]
 }

--- a/layers/base/tsconfig.shared.json
+++ b/layers/base/tsconfig.shared.json
@@ -14,8 +14,21 @@
     "noUncheckedIndexedAccess": true,
     "jsx": "preserve",
     "isolatedModules": true,
-    "typeRoots": ["./node_modules", "./node_modules/@types", "./@types"],
-    "types": ["@types/eslint__js", "@types/node", "@types/postcss-url"]
+    "typeRoots": [
+      "../../node_modules",
+      "../../node_modules/@types",
+      "./@types"
+    ],
+    "types": [
+      "@types/eslint__js",
+      "@types/node",
+      "@types/postcss-url",
+      "@types/uuid",
+      "vue3-toastify/global",
+      "unplugin-icons/types/vue",
+      "vite/client",
+      "vitest/globals"
+    ]
   },
   "vueCompilerOptions": {
     "target": 3

--- a/layers/main/tsconfig.json
+++ b/layers/main/tsconfig.json
@@ -3,20 +3,6 @@
   "extends": [
     "./.nuxt/tsconfig.server.json",
     "./.nuxt/tsconfig.json",
-    "../base/tsconfig.json"
+    "../base/tsconfig.shared.json"
   ],
-  "compilerOptions": {
-    "lib": ["dom", "ES2023"],
-    "typeRoots": [
-      "../../node_modules",
-      "../../node_modules/@types",
-      "./@types"
-    ],
-    "paths": {
-      "~/*": ["./app/*"],
-      "@/*": ["./app/*"],
-      "#base/*": ["../base/*"]
-    },
-  },
-  "exclude": ["node_modules", ".output", "dist"]
 }


### PR DESCRIPTION
### Ticket, Issues
- 無し

### Actions
- mainレイヤーでbaseレイヤーのtsconfig.jsonを継承すると型定義が壊れるので以下の内容で調整しました。
  - ./tsconfig.shared.jsonを./layers/base/tsconfig.shared.jsonへ移動し、./layers/base/tsconfig.jsonに設定している設定を移動したtsconfig.shard.jsonへ移植
  - ./layers/base/tsconfig.jsonと./layers/main/tsconfigl.jsonは./layers/base/tsconfig.shard.jsonを継承するように調整
  各レイヤー以下の記載を最低限するだけで動くようにしました。

```json
{
  // https://nuxt.com/docs/guide/concepts/typescript
  "extends": [
    "./.nuxt/tsconfig.server.json",
    "./.nuxt/tsconfig.json",
    "../base/tsconfig.shared.json"
  ],
}

```
  - そのほかの細かい情報はコメントしました。

### Points and Notes
- 

### Evidences
- 
