### PR TITLE
HmSliderのアクティブなスライド以外もクリッカブルに変更

### DIFF
--- a/layers/base/app/components/hm/HmSlider.vue
+++ b/layers/base/app/components/hm/HmSlider.vue
@@ -36,7 +36,7 @@
               '-center': props.center ? true : false,
             }"
             role="presentation"
-            inert
+            aria-hidden="true"
           >
             <slot name="item"></slot>
           </div>
@@ -60,7 +60,7 @@
               '-center': props.center,
             }"
             role="presentation"
-            inert
+            aria-hidden="true"
           >
             <slot name="item"></slot>
           </div>
@@ -369,10 +369,10 @@ const setActiveSlide = () => {
     sliderItems.forEach((item: HTMLElement, index: number) => {
       if (index === Math.abs(currentSlide.value)) {
         item.classList.add('-active')
-        item.removeAttribute('inert')
+        item.removeAttribute('aria-hidden')
       } else {
         item.classList.remove('-active')
-        item.setAttribute('inert', 'inert')
+        item.setAttribute('aria-hidden', 'true')
       }
     })
   }


### PR DESCRIPTION
### Actions
アクティブなスライド以外をアクセシビリティツリーから削除するアプローチをinert属性からaria-hidden属性に変更し、アクティブでないスライドも活性状態に変更いたしました！
本変更の狙いは、非アクティブ状態なスライドのa要素も押せたり、hoverに反応させたりする事を叶える点にあります。

### 挙動確認用コード例
```
    <HmSlider
      class="slider"
      slidename="slider1"
      :items-id="['slide1-1', 'slide1-2', 'slide1-3']"
      :arrow="false"
      :pagination="true"
      :amount="3"
      :loop="false"
      :center="false"
      :page="false"
      :autoplay="true"
      :interval="7000"
      gap-pc="0px"
      gap-sp="0px"
      width-pc="50"
      width-sp="50"
      :duration="500"
      easing="ease-in-out"
      :draggable="true"
    >
      <template #item>
        <HmSliderItem
          id="slider1-1"
        >
          <a href="./hoge">アクティブなスライド以外もクリックできるように</a>
        </HmSliderItem>
        <HmSliderItem
          id="slider1-2"
        >
          <a href="./hoge">アクティブなスライド以外もクリックできるように</a>
        </HmSliderItem>
        <HmSliderItem
          id="slider1-3"
        >
          <a href="./hoge">アクティブなスライド以外もクリックできるように</a>
        </HmSliderItem>
      </template>
    </HmSlider>
```