### PR TITLE
feat: localePathの引数と戻り値を'/'始まりに統一

### DIFF
--- a/layers/base/app/composables/useLocale.ts
+++ b/layers/base/app/composables/useLocale.ts
@@ -47,8 +47,13 @@ export const useLocale = () => {
     i18n.locale.value = target
   }
 
+  /**
+   * 現在のi18n localeに基づいてlocale固有のパスを返却します。
+   * @param to - '/'から始まる宛先パス
+   * @returns '/'から始まるパス
+   */
   const localePath = (to: string) =>
-    i18n.locale.value === JA ? to : `${i18n.locale.value}${to}`
+    i18n.locale.value === JA ? to : `/${i18n.locale.value}${to}`
 
   return {
     getDefaultLanguage,

--- a/layers/base/app/test/composables/useLocale.spec.ts
+++ b/layers/base/app/test/composables/useLocale.spec.ts
@@ -44,6 +44,6 @@ test('localPath', () => {
   expect(locale.localePath('/path')).toBe('/path')
 
   locale.changeLocale('en')
-  expect(locale.localePath('')).toBe('en')
-  expect(locale.localePath('/path')).toBe('en/path')
+  expect(locale.localePath('')).toBe('/en')
+  expect(locale.localePath('/path')).toBe('/en/path')
 })


### PR DESCRIPTION
### Ticket, Issues
- none

jaとそれ以外で戻り値の形式が違っており、呼び出し元でハンドリングする必要がありました。

```ts
// locale: ja
const path = localePath('/to')
console.log(path) // /to
router.push(path)

// locale: en
const path = localePath('/to')
console.log(path) // en/to
router.push(`/${path}`)
```

### Actions
- localePathメソッドの引数と戻り値の形式を'/'始まりに統一



### Points and Notes
- 破壊的な変更になるため、localePathを使用している箇所をご確認お願いします

### Evidences
- 
