### PR TITLE
HmInputSingleImageの削除ボタンにtypeを付与

### DIFF
--- a/layers/base/app/components/hm/input/HmInputSingleImage.vue
+++ b/layers/base/app/components/hm/input/HmInputSingleImage.vue
@@ -43,6 +43,7 @@ en:
     </p>
     <template v-if="imageUrl && isRemovable">
       <button
+        type="button"
         class="remove"
         @click="removeImage"
       />


### PR DESCRIPTION
### Ticket, Issues
- 無し

### Actions
- 削除処理が何らかの影響で動かなかった際にbutton typeのデフォルトであるsubmitが動いてしまうので調整

### Points and Notes
- 

### Evidences
- 
