### PR TITLE
fix: HaDialogElement.vueのiconをRemixIconに差し替え

### DIFF
--- a/layers/base/app/components/ha/HaDialogElement.vue
+++ b/layers/base/app/components/ha/HaDialogElement.vue
@@ -19,9 +19,7 @@ HaDialogとの違いとして、HaDialogElementは別階層の別要素のz-inde
       @click="closeDialog"
     >
       <slot name="close">
-        <!-- FIXME: アイコンライブラリが使えない。。。 -->
-        <!-- <RiCloseLine class="icon" /> -->
-        ×
+        <RiCloseLine class="icon" />
       </slot>
     </component>
     <div
@@ -39,7 +37,7 @@ HaDialogとの違いとして、HaDialogElementは別階層の別要素のz-inde
 </template>
 
 <script lang="ts" setup>
-// import RiCloseLine from '~icons/ri/close-line'
+import RiCloseLine from '~icons/ri/close-line'
 
 export type Props = {
   closeButtonHtmlTag?: string


### PR DESCRIPTION
### Ticket, Issues
- FIXMEの事項が解消されているため差し替え対応

### Actions
- コメントアウトを解除

### Points and Notes
- 

### Evidences

テストページを作成して確認

<img width="1217" height="453" alt="image" src="https://github.com/user-attachments/assets/3a0e7ab5-38a5-4f33-a8a1-a245b8113d62" />
