### PR TITLE
feat: HmDialogElement.vue のclosedbyをoptionalに変更

### DIFF
--- a/layers/base/app/components/hm/HmDialogElement.vue
+++ b/layers/base/app/components/hm/HmDialogElement.vue
@@ -44,11 +44,12 @@ import HaDialogElement from '#base/app/components/ha/HaDialogElement.vue'
 export type Props = {
   openButtonHtmlTag?: string
   closeButtonHtmlTag?: string
-  closedby: 'any' | 'closerequest' | 'none' | undefined
+  closedby?: 'any' | 'closerequest' | 'none' | undefined
 }
 const props = withDefaults(defineProps<Props>(), {
   openButtonHtmlTag: 'button',
   closeButtonHtmlTag: 'button',
+  closedby: 'any',
 })
 
 // aria-label用のi18n


### PR DESCRIPTION
### Ticket, Issues
- https://github.com/PublicHIKKY/vket-boilerplate-nuxt/pull/81 の続き

### Actions
- 後方互換のために`closedby`をoptionalに変更
  - 基本的に`any`でよいはずなので`default: any`とし、変更の必要がある場合に親コンポーネントで指定する形としました

### Points and Notes
- 

### Evidences
- 
