### PR TITLE
fix: ApiAccess型をFunctionに変更

### DIFF
--- a/layers/base/app/utils/default-factory.ts
+++ b/layers/base/app/utils/default-factory.ts
@@ -4,7 +4,8 @@ import type { Method as DefaultMethods } from '#base/app/utils/default-api'
 /**
  * The parent type for each method of `'get' | 'post' | 'put' | 'delete'` in each repository
  */
-export type ApiAccess = (...args: unknown[]) => Promise<unknown>
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+export type ApiAccess = Function
 
 /**
  * For use when creating `#main/app/utils/factory.ts`.


### PR DESCRIPTION
### Ticket, Issues
typescriptのバージョンが上がったからかunknown型で定義されていた`ApiAccess`が原因でエラーとなっていました。

引数があるときのみエラーになるため、このリポジトリでは発生していません。

<img width="701" height="279" alt="image" src="https://github.com/user-attachments/assets/0b37e364-4e3e-41f7-8d8d-b3ffe2f66050" />
<img width="538" height="98" alt="image" src="https://github.com/user-attachments/assets/3afd1da5-459c-44a4-bd8a-00cb60064ac8" />


### Actions
- Repository Factoryの設計であることが担保できればよいため、緩く`Function`で定義しました

### Points and Notes
- 

### Evidences

